### PR TITLE
scripts/ci: Copy logs of failed builds to _build/failures

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -40,6 +40,7 @@ GIT_DIR = path.join(BUILD_DIR, 'git')
 SOURCE_DIR = path.join(BUILD_DIR, 'source')
 BINARY_DIR = path.join(BUILD_DIR, 'binary')
 REPO_DIR = path.join(BUILD_DIR, 'repos')
+FAILURES_DIR = path.join(BUILD_DIR, 'failures')
 
 # Architectures to build for
 build_archs = {
@@ -240,8 +241,12 @@ def dpkg_source(name, git, series):
         except Exception as ex:
             message = "\x1B[1m{} commit {} on {}: failed to build source: {!r}\x1B[0m\n".format(source_name, git.id, series.codename, ex)
 
-            build_log = path.join(SOURCE_DIR, source_name + "_" + path_version + "_source.build")
+            build_log_filename = source_name + "_" + path_version + "_source.build"
+            build_log = path.join(SOURCE_DIR, build_log_filename)
+            failure_build_log = path.join(FAILURES_DIR, build_log_filename)
             if path.exists(build_log):
+                shutil.copyfile(build_log, failure_build_log)
+
                 with open(build_log, 'r') as f:
                     message += f.read()
 
@@ -315,7 +320,9 @@ def dpkg_binary(dsc_path, name, git, series, build_arch, build_all):
     if not debs:
         return []
 
-    build_log = path.join(BINARY_DIR, source_name + "_" + path_version + "_" + build_arch + ".build")
+    build_log_filename = source_name + "_" + path_version + "_" + build_arch + ".build"
+    build_log = path.join(BINARY_DIR, build_log_filename)
+    failure_build_log = path.join(FAILURES_DIR, build_log_filename)
 
     if found_binaries:
         print("\x1B[1m{} commit {} on {}: binaries for {} already built\x1B[0m".format(source_name, git.id, series.codename, build_arch), flush=True)
@@ -367,6 +374,8 @@ def dpkg_binary(dsc_path, name, git, series, build_arch, build_all):
                 print("\x1B[1m{} commit {} on {}: failed to report build failure: {!r}\x1B[0m\n".format(source_name, git.id, series.codename, ex_s))
 
             if path.exists(build_log):
+                shutil.copyfile(build_log, failure_build_log)
+
                 with open(build_log, 'rb') as f:
                     sys.stdout.buffer.write(f.read())
             else:
@@ -593,6 +602,7 @@ def ci():
     create_dir(GIT_DIR)
     create_dir(SOURCE_DIR)
     create_dir(BINARY_DIR)
+    create_dir(FAILURES_DIR)
     recreate_dir(REPO_DIR)
 
     all_pocket_series = {}

--- a/scripts/ci
+++ b/scripts/ci
@@ -385,6 +385,9 @@ def dpkg_binary(dsc_path, name, git, series, build_arch, build_all):
 
             return []
     else:
+        if path.exists(build_log):
+            shutil.copyfile(build_log, failure_build_log)
+
         print("\x1B[1m{} commit {} on {}: binaries already failed to build\x1B[0m".format(source_name, git.id, series.codename), flush=True)
 
     for deb_path in debs:
@@ -602,8 +605,11 @@ def ci():
     create_dir(GIT_DIR)
     create_dir(SOURCE_DIR)
     create_dir(BINARY_DIR)
-    create_dir(FAILURES_DIR)
     recreate_dir(REPO_DIR)
+
+    if path.isdir(FAILURES_DIR):
+        shutil.rmtree(FAILURES_DIR)
+    os.mkdir(FAILURES_DIR)
 
     all_pocket_series = {}
     for repo_name, pocket_series in foreach_repo_parallel(callback, args.repos, args.dev).items():


### PR DESCRIPTION
@jackpot51 Does this seem like what you're looking for? I was somewhat unsure about whether the script would need to clear the `failures` directory.

It just copies the logs, for both source and binary packages, with the same file names as the logs have in `_build/source` and `_build/binary`.

If everything is fine, I can add an action on Jenkins to archive these files.