### PR TITLE
Update "apt local" for Groovy

### DIFF
--- a/scripts/apt
+++ b/scripts/apt
@@ -75,7 +75,7 @@ case "$1" in
 		done
 		;;
 	local)
-		grep "^deb ${REPOS}" /etc/apt/sources.list | \
+		grep "^deb ${REPOS}" /etc/apt/sources.list{,.d/*} | \
 			cut -d " " -f2 |
 			sed -s "s#${REPOS}##"
 		;;


### PR DESCRIPTION
On Groovy, adding staging sources using `./scripts/apt add` adds them to individual files inside of sources.list.d, not the main sources.list file. Since `./scripts/apt local` currently only checks the main sources.list file, it doesn't work on Groovy. This PR checks both sources.list and sources.list.d/*, which gets the `local` listing working on Groovy while not breaking Focal compatibility.