### PR TITLE
Use Repolib utilities to add/remove testing repos

### DIFF
--- a/scripts/apt
+++ b/scripts/apt
@@ -92,8 +92,8 @@ case "$1" in
 			done
 			LINE="deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
 			sudo echo # Workaround for not having an assume-yes option in remove
-			sudo apt-manage remove popdev-${LOCALREMOTE}$r_newrepo${DEVLINE} || \
-				# &> /dev/null || \
+			sudo apt-manage remove -y popdev-${LOCALREMOTE}$r_newrepo${DEVLINE} \
+				&> /dev/null || \
 				sudo add-apt-repository -r -s "${LINE}"
 
 			echo "Removing preference for '$newrepo'"

--- a/scripts/apt
+++ b/scripts/apt
@@ -93,10 +93,6 @@ case "$1" in
 		grep "^deb ${REPOS}" /etc/apt/sources.list{,.d/*} | \
 			cut -d " " -f2 |
 			sed -s "s#${REPOS}##"
-		while read line
-		do
-			printf "%s\n" "$line"
-		done <<< $(bash -c "apt-manage list | grep popdev" 2>$1)
 		;;
 	remote)
 		curl -s "${REPOS}" | \

--- a/scripts/apt
+++ b/scripts/apt
@@ -55,7 +55,11 @@ case "$1" in
 			EOF
 
 			echo "Adding repository for '$newrepo'"
-			sudo add-apt-repository -s "deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
+			sudo apt-manage add "deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main" \
+				--source-code \
+				--ident popdev-$newrepo \
+				--name "Pop Development Branch $newrepo" || \
+				sudo add-apt-repository -s "deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
 		done
 		;;
 	remove)
@@ -68,7 +72,9 @@ case "$1" in
 		for newrepo in "${ARGV[@]:1}"
 		do
 			echo "Removing repository for '$newrepo'"
-			sudo add-apt-repository -r -s "deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
+			sudo apt-manage remove popdev-$newrepo || \
+				sudo add-apt-repository -r -s \
+					"deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
 
 			echo "Removing preference for '$newrepo'"
 			sudo rm -f "/etc/apt/preferences.d/pop-os-staging-${newrepo//./_}"

--- a/scripts/apt
+++ b/scripts/apt
@@ -21,8 +21,10 @@ done
 
 POP_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")"
 REPOS="http://apt.pop-os.org/staging/"
+DEVLINE=''
 if [ "$DEV" == "1" ]
 then
+	DEVLINE='-dev'
     if [ "$LOCAL" == "1" ]
     then
         REPOS="file://${POP_DIR}/_build/repos/dev/"
@@ -32,6 +34,12 @@ then
 elif [ "$LOCAL" == "1" ]
 then
     REPOS="file://${POP_DIR}/_build/repos/"
+fi
+
+LOCALREMOTE=''
+if [ "$LOCAL" == "1" ]
+then
+	LOCALREMOTE='local-'
 fi
 
 case "$1" in
@@ -55,11 +63,12 @@ case "$1" in
 			EOF
 
 			echo "Adding repository for '$newrepo'"
-			sudo apt-manage add "deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main" \
+			LINE="deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
+			sudo apt-manage add "${LINE}" \
 				--source-code \
-				--ident popdev-$newrepo \
+				--ident popdev-${LOCALREMOTE}$newrepo${DEVLINE} \
 				--name "Pop Development Branch $newrepo" || \
-				sudo add-apt-repository -s "deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
+				sudo add-apt-repository -s "${LINE}"
 		done
 		;;
 	remove)
@@ -72,9 +81,9 @@ case "$1" in
 		for newrepo in "${ARGV[@]:1}"
 		do
 			echo "Removing repository for '$newrepo'"
-			sudo apt-manage remove popdev-$newrepo || \
-				sudo add-apt-repository -r -s \
-					"deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
+			LINE="deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
+			sudo apt-manage remove popdev-${LOCALREMOTE}-$newrepo${DEVLINE} || \
+				sudo add-apt-repository -r -s "${LINE}"
 
 			echo "Removing preference for '$newrepo'"
 			sudo rm -f "/etc/apt/preferences.d/pop-os-staging-${newrepo//./_}"
@@ -84,6 +93,10 @@ case "$1" in
 		grep "^deb ${REPOS}" /etc/apt/sources.list | \
 			cut -d " " -f2 |
 			sed -s "s#${REPOS}##"
+		while read line
+		do
+			printf "%s\n" "$line"
+		done <<< $(bash -c "apt-manage list | grep popdev" 2>$1)
 		;;
 	remote)
 		curl -s "${REPOS}" | \

--- a/scripts/apt
+++ b/scripts/apt
@@ -68,11 +68,16 @@ case "$1" in
 
 			echo "Adding repository for '$newrepo'"
 			LINE="deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
-			sudo apt-manage add "${LINE}" \
-				--source-code \
-				--ident popdev-${LOCALREMOTE}$newrepo${DEVLINE} \
-				--name "Pop Development Branch $newrepo" || \
+			if command -v apt-manage
+			then
+				sudo apt-manage add "${LINE}" \
+					--source-code \
+					--ident popdev-${LOCALREMOTE}$newrepo${DEVLINE} \
+					--name "Pop Development Branch $newrepo" 
+				sudo apt-get update
+			else
 				sudo add-apt-repository -s "${LINE}"
+			fi
 		done
 		;;
 	remove)
@@ -91,11 +96,13 @@ case "$1" in
 				do r_newrepo=${r_newrepo//$i/-}
 			done
 			LINE="deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
-			sudo echo # Workaround for not having an assume-yes option in remove
-			sudo apt-manage remove -y popdev-${LOCALREMOTE}$r_newrepo${DEVLINE} \
-				&> /dev/null || \
+			if command -v apt-manage > /dev/null
+			then
+				sudo apt-manage remove -y popdev-${LOCALREMOTE}$r_newrepo${DEVLINE} 
+				sudo apt-get update
+			else
 				sudo add-apt-repository -r -s "${LINE}"
-
+			fi
 			echo "Removing preference for '$newrepo'"
 			sudo rm -f "/etc/apt/preferences.d/pop-os-staging-${newrepo//./_}"
 		done

--- a/scripts/apt
+++ b/scripts/apt
@@ -19,6 +19,10 @@ do
 	fi
 done
 
+# We may get some chars translated out of Idents.
+HYPHENS='@ # $ % ^ & * + = .'
+UNDERSCORES='| / < > ,'
+
 POP_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")"
 REPOS="http://apt.pop-os.org/staging/"
 DEVLINE=''
@@ -67,7 +71,7 @@ case "$1" in
 			sudo apt-manage add "${LINE}" \
 				--source-code \
 				--ident popdev-${LOCALREMOTE}$newrepo${DEVLINE} \
-				--name "Pop Development Branch $newrepo" &> /dev/null || \
+				--name "Pop Development Branch $newrepo" || \
 				sudo add-apt-repository -s "${LINE}"
 		done
 		;;
@@ -81,9 +85,15 @@ case "$1" in
 		for newrepo in "${ARGV[@]:1}"
 		do
 			echo "Removing repository for '$newrepo'"
+			r_newrepo=${newrepo//+(@#$%^&*+=.)/-}
+			r_newrepo=$newrepo
+			for i in $HYPHENS
+				do r_newrepo=${r_newrepo//$i/-}
+			done
 			LINE="deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
-			sudo apt-manage remove popdev-${LOCALREMOTE}-$newrepo${DEVLINE} \
-				&> /dev/null || \
+			sudo echo # Workaround for not having an assume-yes option in remove
+			sudo apt-manage remove popdev-${LOCALREMOTE}$r_newrepo${DEVLINE} || \
+				# &> /dev/null || \
 				sudo add-apt-repository -r -s "${LINE}"
 
 			echo "Removing preference for '$newrepo'"

--- a/scripts/apt
+++ b/scripts/apt
@@ -67,7 +67,7 @@ case "$1" in
 			sudo apt-manage add "${LINE}" \
 				--source-code \
 				--ident popdev-${LOCALREMOTE}$newrepo${DEVLINE} \
-				--name "Pop Development Branch $newrepo" || \
+				--name "Pop Development Branch $newrepo" &> /dev/null || \
 				sudo add-apt-repository -s "${LINE}"
 		done
 		;;
@@ -82,7 +82,8 @@ case "$1" in
 		do
 			echo "Removing repository for '$newrepo'"
 			LINE="deb ${REPOS}$newrepo ${UBUNTU_CODENAME} main"
-			sudo apt-manage remove popdev-${LOCALREMOTE}-$newrepo${DEVLINE} || \
+			sudo apt-manage remove popdev-${LOCALREMOTE}-$newrepo${DEVLINE} \
+				&> /dev/null || \
 				sudo add-apt-repository -r -s "${LINE}"
 
 			echo "Removing preference for '$newrepo'"


### PR DESCRIPTION
Since we now use Repolib for most repository management, it makes sense to do so for testing purposes and move dev repos out of sources.list. This PR attempts to use repolib/apt-manage for adding and removing repositories for testing, with a graceful fallback on add-apt-repository if repolib is not install (for continued functionality on Focal and earlier). 

Requires pop-os/repolib#35