### PR TITLE
Add a script to compare versions of packages in Pop repos with Ubuntu

### DIFF
--- a/scripts/apt-compare
+++ b/scripts/apt-compare
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import apt
+import os
+import re
+import repolib
+import sys
+import tempfile
+
+POP_ORIGINS = ["LP-PPA-system76-pop"]
+SUITE = "groovy"
+
+def pop_origins(ver):
+    return (o for o in ver.origins if o.origin in POP_ORIGINS)
+
+if len(sys.argv) >= 2:
+    SUITE = sys.argv[1]
+
+with tempfile.TemporaryDirectory() as rootdir:
+    source_dir = f"{rootdir}/etc/apt/sources.list.d"
+    os.makedirs(source_dir)
+
+    apt.apt_pkg.config.set("Acquire::AllowInsecureRepositories", "true")
+
+    def add_source(name, source):
+        with open(f"{source_dir}/{name}.sources", 'w') as f:
+            f.write(source.dump())
+
+    system_source = repolib.SystemSource()
+    system_source.suites = [SUITE, f"{SUITE}-security", f"{SUITE}-updates", f"{SUITE}-backports"]
+    add_source("system", system_source)
+
+    pop_ppa = repolib.PPALine("ppa:system76/pop")
+    pop_ppa.suites = [SUITE]
+    add_source("pop-os-ppa", pop_ppa)
+
+    cache = apt.Cache(rootdir=rootdir, memonly=True)
+    cache.update()
+    cache.open()
+
+    for pkg in cache:
+        max_ver = max(pkg.versions)
+        pop_ver = max((v for v in pkg.versions if any(pop_origins(v))), default=None)
+        if pop_ver is not None and max_ver > pop_ver:
+            pop_origin = next(pop_origins(pop_ver))
+            max_origin = max_ver.origins[0]
+            print(pkg)
+            print(f"   {pop_origin.origin}: {pop_ver.version}")
+            print(f"   {max_origin.origin}: {max_ver.version}")


### PR DESCRIPTION
`./scripts/apt-compare` while print a list of packages where Ubuntu Groovy has a newer version than Pop!_OS Groovy, based on how Debian package versions compare.

`./scripts/apt-compare focal` or `./scripts/apt-compare bionic` perform the same comparison for Focal or Bionic repos.

Implemented using `python-apt` and `repolib`.