### PR TITLE
scripts/launchpad: Remove xenial

### DIFF
--- a/scripts/launchpad
+++ b/scripts/launchpad
@@ -29,7 +29,6 @@ BINARY_DIR = path.join(BUILD_DIR, 'binary')
 REPO_DIR = path.join(BUILD_DIR, 'repos')
 
 codenames = (
-    "xenial",
     "bionic",
     "focal",
     "groovy",


### PR DESCRIPTION
As far as I'm aware there's no reason this should run for xenial anymore.