### PR TITLE
Change recommendations to match actual licensing

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,9 +1,9 @@
 In general, it is preferred that Pop!\_OS projects are licensed `GPL-3.0-only`.
 There are some exceptions to this:
 
-- `LGPL-3.0-only` may be used if it is desired to allow dynamic linkage with
-  projects that use other licenses
-- `MPL-2.0` may be used if it is desired to allow both static and dynamic
-  linkage with projects that use other licenses
+- `MPL-2.0` may be used if it is desired to allow linkage with projects that use other licenses, but require modifications to remain open source
+- `MIT OR Apache-2.0` may be used if it is desired to have wide use, with potential downstream modifications, in software of any license
+
+To summarize: Use `GPL-3.0-only` for applications, `MPL-2.0` for libraries with utility in the open source community, and `MIT OR Apache-2.0` for foundational libraries with utility anywhere.
 
 Please use SPDX identifiers in every source file: https://spdx.dev/ids/


### PR DESCRIPTION
We did not end up using `LGPL-3.0-only` often due to Rust primarily utilizing static linking. As we shift Pop!_OS to use even more Rust, and to provide even more parts of the Rust ecosystem, it has become necessary in some cases to evaluate alternative licenses that are more permissive than `MPL-2.0`. This has led to potential re-licensing of "foundational" Rust libraries that have wide usage as `MIT OR Apache-2.0`, such as cosmic-text: https://github.com/pop-os/cosmic-text/pull/7

[View new LICENSING.md](https://github.com/pop-os/pop/blob/2fa7e3cc4cc83f53b57305835bde34a98b40595a/LICENSING.md)

To clarify the use of each license, I have added a summary line:

Use `GPL-3.0-only` for applications, `MPL-2.0` for libraries with utility in the open source community, and `MIT OR Apache-2.0` for foundational libraries with utility anywhere.

I am seeking approval from Carl as well as the members of my team on these new recommendations:

- [x] @13r0ck 
- [x] @crawfxrd 
- [x] @Drakulix 
- [ ] @ids1024 
- [x] @isantop 
- [x] @jackpot51 
- [x] @mmstick 
- [x] @wash2 
- [x] @WatchMkr 