### PR TITLE
Add requirements for Nested container builds

### DIFF
--- a/scripts/sbuild
+++ b/scripts/sbuild
@@ -39,7 +39,6 @@ if not path.exists(chroot_path):
         "--include=gnupg",
         "--components=main,restricted,universe,multiverse",
         "--arch=" + args.arch,
-        "--merged-usr",
         args.dist,
         chroot_path,
         "http://archive.ubuntu.com/ubuntu"

--- a/scripts/sbuild
+++ b/scripts/sbuild
@@ -39,12 +39,14 @@ if not path.exists(chroot_path):
         "--include=gnupg",
         "--components=main,restricted,universe,multiverse",
         "--arch=" + args.arch,
+        "--merged-usr",
         args.dist,
         chroot_path,
         "http://archive.ubuntu.com/ubuntu"
     ])
 
 sbuild = [
+    "sudo",
     "sbuild",
     "--dist=" + args.dist,
     "--arch=" + args.arch,
@@ -58,6 +60,7 @@ sbuild = [
     "--extra-repository=deb-src " + apt_proposed + " " + args.dist + " main",
     "--extra-repository-key=" + path.join(os.getcwd(), "scripts", apt_key),
     "--no-apt-distupgrade",
+    "--chroot-setup-commands=mkdir -p /sbuild-nonexistent",
 ]
 
 check_call(sbuild, cwd=args.repo)

--- a/scripts/sbuild
+++ b/scripts/sbuild
@@ -3,8 +3,9 @@
 import argparse
 import distro
 import os
+import re
 from os import path
-from subprocess import check_call
+from subprocess import check_call, check_output
 import sys
 
 parser = argparse.ArgumentParser(description="Run Pop!_OS build process")
@@ -31,7 +32,6 @@ else:
     apt_release = "http://apt.pop-os.org/release"
     apt_proposed = "http://apt.pop-os.org/staging/master"
 
-
 chroot_path = "/srv/chroot/" + args.dist + "-" + args.arch + "-sbuild"
 if not path.exists(chroot_path):
     check_call([
@@ -44,8 +44,14 @@ if not path.exists(chroot_path):
         "http://archive.ubuntu.com/ubuntu"
     ])
 
-sbuild = [
-    "sudo",
+requires_sudo = [ "Fetch URL: git@github.com:pop-os/mesa.git" ]
+
+fetch_path = [ "git", "remote", "show", "origin" ]
+origin_data = check_output(fetch_path, cwd=args.repo).decode("utf-8")
+
+sudo = [ "sudo" ] if re.search("|".join(require_sudo), origin_data) else []
+
+sbuild = sudo + [
     "sbuild",
     "--dist=" + args.dist,
     "--arch=" + args.arch,


### PR DESCRIPTION
This adds some quirks to make podman work in the sbuild environment. Allowing for complex builds that build on a different OS and/or OS version than the final packaging is for.

~~This should likely be modified to only build with sudo permissions for a specific set of repos, that can only be changed via PR and review. We likely don't want community PRs building with sudo permissions.~~ Edit: Done

See https://github.com/pop-os/mesa/pull/11 for more info