### PR TITLE
Add gnome-shell to patch list on Ubuntu

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -18,6 +18,7 @@ DEV_REPOS = (
     "gdm3",
     "gnome-desktop3",
     "gnome-settings-daemon",
+    "gnome-shell",
     "gnome-shell-extension-system76-power",
     "hidpi-daemon",
     "libabigail",

--- a/scripts/pop-ci/src/main.rs
+++ b/scripts/pop-ci/src/main.rs
@@ -36,6 +36,7 @@ static DEV_REPOS: &'static [&'static str] = &[
     "gdm3",
     "gnome-desktop3",
     "gnome-settings-daemon",
+    "gnome-shell",
     "gnome-shell-extension-system76-power",
     "hidpi-daemon",
     "libabigail",


### PR DESCRIPTION
Link: https://github.com/pop-os/nvidia-graphics-drivers/pull/178#issuecomment-1444352463

This is not the first time that this has happened either.