### PR TITLE
Enable builds for Ubuntu 23.04 Lunar

### DIFF
--- a/scripts/launchpad
+++ b/scripts/launchpad
@@ -39,6 +39,7 @@ if args.dev:
         "focal",
         "jammy",
         "kinetic",
+        "lunar",
     )
 else:
     owner = lp.people["system76"]

--- a/scripts/pop-ci/src/repo.rs
+++ b/scripts/pop-ci/src/repo.rs
@@ -127,6 +127,7 @@ impl Suite {
         Self("focal", "20.04", true, SuiteDistro::All),
         Self("jammy", "22.04", true, SuiteDistro::All),
         Self("kinetic", "22.10", false, SuiteDistro::Ubuntu),
+        Self("lunar", "23.04", false, SuiteDistro::Ubuntu),
     ];
 
     pub fn new(id: &str) -> Option<Self> {


### PR DESCRIPTION
I'm not sure if anything needs to be done elsewhere, or if this is enough to have CI trigger builds for the `pre-stable` PPA. Then the `launchpad` script should be able to copy to `stable`.