### PR TITLE
update kbuild on Ubuntu for virtualbox

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -21,6 +21,7 @@ DEV_REPOS = (
     "gnome-shell",
     "gnome-shell-extension-system76-power",
     "hidpi-daemon",
+    "kbuild",
     "libabigail",
     "libasound2",
     "libbpf",

--- a/scripts/pop-ci/src/main.rs
+++ b/scripts/pop-ci/src/main.rs
@@ -39,6 +39,7 @@ static DEV_REPOS: &'static [&'static str] = &[
     "gnome-shell",
     "gnome-shell-extension-system76-power",
     "hidpi-daemon",
+    "kbuild",
     "libabigail",
     "libasound2",
     "libbpf",


### PR DESCRIPTION
This will enable virtualbox 7.0.8 to be backported to Ubuntu.