### PR TITLE
Call debian/rules clean before source debuild

### DIFF
--- a/scripts/pop-ci/src/main.rs
+++ b/scripts/pop-ci/src/main.rs
@@ -710,12 +710,16 @@ sudo sbuild-update \
                             .and_then(check_status)?;
                     }
 
-                    process::Command::new("fakeroot")
-                        .arg("debian/rules")
-                        .arg("clean")
-                        .current_dir(&archive)
-                        .status()
-                        .and_then(check_status)?;
+                    // Linux needs to have debian/rules clean run to build with the automatic
+                    // version number
+                    if repo_name == "linux" {
+                        process::Command::new("fakeroot")
+                            .arg("debian/rules")
+                            .arg("clean")
+                            .current_dir(&archive)
+                            .status()
+                            .and_then(check_status)?;
+                    }
 
                     process::Command::new("debuild")
                         .arg("--preserve-envvar").arg("PATH")

--- a/scripts/pop-ci/src/main.rs
+++ b/scripts/pop-ci/src/main.rs
@@ -710,6 +710,13 @@ sudo sbuild-update \
                             .and_then(check_status)?;
                     }
 
+                    process::Command::new("fakeroot")
+                        .arg("debian/rules")
+                        .arg("clean")
+                        .current_dir(&archive)
+                        .status()
+                        .and_then(check_status)?;
+
                     process::Command::new("debuild")
                         .arg("--preserve-envvar").arg("PATH")
                         .arg("--set-envvar").arg(format!("SOURCE_DATE_EPOCH={}", commit_timestamp))


### PR DESCRIPTION
This fixes issues uploading new kernels to launchpad. Draft until I confirm that the kernel builds on launchpad.