### PR TITLE
Add resolute (26.04)

### DIFF
--- a/scripts/launchpad
+++ b/scripts/launchpad
@@ -38,6 +38,7 @@ if args.dev:
         "focal",
         "jammy",
         "noble",
+        "resolute",
     )
 else:
     owner = lp.people["system76"]

--- a/scripts/launchpad-clean
+++ b/scripts/launchpad-clean
@@ -22,6 +22,7 @@ codenames = (
     "jammy",
     "noble",
     "oracular",
+    "resolute",
 )
 
 for repo in repos:

--- a/scripts/pop-ci/src/repo.rs
+++ b/scripts/pop-ci/src/repo.rs
@@ -131,6 +131,7 @@ impl Suite {
         Self("focal", "20.04", SuiteWildcard::Focal, SuiteDistro::All),
         Self("jammy", "22.04", SuiteWildcard::All, SuiteDistro::All),
         Self("noble", "24.04", SuiteWildcard::All, SuiteDistro::All),
+        Self("resolute", "26.04", SuiteWildcard::All, SuiteDistro::All),
     ];
 
     pub fn new(id: &str) -> Option<Self> {

--- a/scripts/wildcard
+++ b/scripts/wildcard
@@ -22,7 +22,7 @@ def callback(repo):
 		else:
 			suffix = "pop"
 
-		for codename in ["focal", "jammy", "noble"]:
+		for codename in ["focal", "jammy", "noble", "resolute"]:
 			matches = []
 			wildcard_master = "master"
 			codename_master = wildcard_master + "_" + codename


### PR DESCRIPTION
In order to make this work, I have made the resolute repos available using copies from noble.

- Ubuntu stable: https://launchpad.net/~system76-dev/+archive/ubuntu/stable/+packages?field.name_filter=&field.status_filter=published&field.series_filter=resolute
- Ubuntu pre-stable: https://launchpad.net/~system76-dev/+archive/ubuntu/pre-stable/+packages?field.name_filter=&field.status_filter=published&field.series_filter=resolute
- Pop!_OS release: https://apt.pop-os.org/release/dists/resolute/
- Pop!_OS staging: https://apt.pop-os.org/staging/master/dists/resolute/