### PR TITLE
Exclusion list for building master for jammy

### DIFF
--- a/scripts/pop-ci/src/config.rs
+++ b/scripts/pop-ci/src/config.rs
@@ -63,3 +63,11 @@ pub static DEV_REPOS: &'static [&'static str] = &[
 
 /// Repos from DEV_REPOS to build for only Ubuntu
 pub static DEV_ONLY_REPOS: &'static [&'static str] = &["system76-ubuntu-repo"];
+
+/// Repos that no longer support Pop 22.04, and must not be build wildcard branches (master) for jammy
+pub static JAMMY_EXCLUDED_REPOS: &'static [&'static str] = &[
+    "cosmic-bg",
+    "cosmic-comp",
+    "cosmic-settings",
+    "xdg-desktop-portal-cosmic",
+];

--- a/scripts/pop-ci/src/repo.rs
+++ b/scripts/pop-ci/src/repo.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeMap, fs, path::PathBuf};
 
+use crate::config::JAMMY_EXCLUDED_REPOS;
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Arch(&'static str);
 
@@ -110,6 +112,7 @@ impl RepoInfo {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum SuiteWildcard {
     None,
+    Jammy,
     All,
 }
 
@@ -126,7 +129,7 @@ pub struct Suite(&'static str, &'static str, SuiteWildcard, SuiteDistro);
 impl Suite {
     // This list has every supported Pop!_OS and Ubuntu release
     pub const ALL: &'static [Self] = &[
-        Self("jammy", "22.04", SuiteWildcard::All, SuiteDistro::All),
+        Self("jammy", "22.04", SuiteWildcard::Jammy, SuiteDistro::All),
         Self("noble", "24.04", SuiteWildcard::All, SuiteDistro::All),
         Self("questing", "25.10", SuiteWildcard::All, SuiteDistro::Ubuntu),
         Self("resolute", "26.04", SuiteWildcard::All, SuiteDistro::All),
@@ -149,9 +152,10 @@ impl Suite {
         self.1
     }
 
-    pub fn wildcard(&self, _repo_name: &str) -> bool {
+    pub fn wildcard(&self, repo_name: &str) -> bool {
         match &self.2 {
             SuiteWildcard::None => false,
+            SuiteWildcard::Jammy => !JAMMY_EXCLUDED_REPOS.contains(&repo_name),
             SuiteWildcard::All => true,
         }
     }


### PR DESCRIPTION
This adds a list of repos that their master branch should not be built for Jammy.
The list I added already have a separate `master_jammy` branch, and Jammy build keeps failing for them.

This is based on previous code we had for focal.

Feel free to close this if you don't care, I had to try!

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

